### PR TITLE
Fix typo res->result

### DIFF
--- a/utility/favoritesQuery.js
+++ b/utility/favoritesQuery.js
@@ -127,7 +127,7 @@ var getLivelink = function (req) {
             if (err || result.error) {
                 console.log(err)
                 console.log(result)
-                createLivelinkTable(req, res).then(() => {
+                createLivelinkTable(req, result).then(() => {
                     hdb_callout.callHarperDB(call_object, operation, function (err2, result2) {
                         resolve(result2);
                     });


### PR DESCRIPTION
After running `node app.js` and trying to navigate to a new route my terminal spit out a reference error for an undefined variable `res`

```
{ error: 'invalid table harperdb_studio.livelink' }
/Users/ethanarrowood/Documents/Projects/HarperDB_Studio/utility/favoritesQuery.js:130
                createLivelinkTable(req, res).then(() => {
                                         ^

ReferenceError: res is not defined
    at /Users/ethanarrowood/Documents/Projects/HarperDB_Studio/utility/favoritesQuery.js:130:42
    at IncomingMessage.<anonymous> (/Users/ethanarrowood/Documents/Projects/HarperDB_Studio/utility/harperDBCallout.js:32:23)
    at IncomingMessage.emit (events.js:185:15)
    at endReadableNT (_stream_readable.js:1101:12)
    at process._tickCallback (internal/process/next_tick.js:114:19)
```

I believe it was supposed to be defined as `result` and now the app is working as expected.