### PR TITLE
Add node version to package.json engines

### DIFF
--- a/hdb_studio.js
+++ b/hdb_studio.js
@@ -119,32 +119,28 @@ passport.deserializeUser(function (user, done) {
 runServer();
 
 function runServer() {
-    if (process.version >= 'v8.11.0') {
-        let http_port = config.http_port;
-        if (!http_port && !config.https_port) {
-            http_port = DEFAULT_HTTP_PORT;
-        }
-
-        if (http_port) {
-            http.createServer(app).listen(http_port, () => {                
-                console.log('HarperDB Studio running on port ' + http_port);
-            });
-        }
-
-        if (config.https_port && config.https_key_path && config.https_cert_path) {
-            let credentials = {
-                key: fs.readFileSync(config.https_key_path),
-                cert: fs.readFileSync(config.https_cert_path)
-            };
-
-            https.createServer(credentials, app)
-                .listen(config.https_port, function () {
-                    console.log('HarperDB Studio running on port ' + config.https_port);
-                });
-        }
+    let http_port = config.http_port;
+    if (!http_port && !config.https_port) {
+        http_port = DEFAULT_HTTP_PORT;
     }
-    else
-        console.log(" HarperDB Studio requires Node.js version 8.11 or higher");
+
+    if (http_port) {
+        http.createServer(app).listen(http_port, () => {                
+            console.log('HarperDB Studio running on port ' + http_port);
+        });
+    }
+
+    if (config.https_port && config.https_key_path && config.https_cert_path) {
+        let credentials = {
+            key: fs.readFileSync(config.https_key_path),
+            cert: fs.readFileSync(config.https_cert_path)
+        };
+
+        https.createServer(credentials, app)
+            .listen(config.https_port, function () {
+                console.log('HarperDB Studio running on port ' + config.https_port);
+            });
+    }
 }
 
 

--- a/hdb_studio.js
+++ b/hdb_studio.js
@@ -116,9 +116,23 @@ passport.deserializeUser(function (user, done) {
     done(null, user);
 });
 
+function checkNodeVersion() {
+    const version = process.version;
+
+    const pattern = new RegExp('v(\\d*)\\.(\\d*)\\.(\\d*)');
+    const match = version.match(pattern);
+
+    if ( match[1] < 8 && match[2] < 11 ) {
+        console.warn('We detect you are using an old version of Node.js \n Update to at least v8.11.* in order to use HarperDB Studio properly.');
+    }
+}
+
 runServer();
 
 function runServer() {
+
+    checkNodeVersion()
+
     let http_port = config.http_port;
     if (!http_port && !config.https_port) {
         http_port = DEFAULT_HTTP_PORT;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "mocha"
   },
+  "engines": {
+    "node": ">=8.11.0"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Node version should not be enforced within the file itself. I've added the desired Node version to package.json as an `engine`. I believe it is the users responsibility to verify the correct version of node. We could add Node as a dependency so when users run 'npm install' it'll make sure they are using the right Node version: https://nitayneeman.com/posts/standardizing-node.js-version-in-an-npm-package/#install-as-devdependency

I'm not sure how practical this is because I don't use `nvm` to manage my local Node install.

Closes #17

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harperdb/harperdb_studio/18)
<!-- Reviewable:end -->
